### PR TITLE
Fixed Multitap Support

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -517,13 +517,18 @@ static void report_buttons (void)
 		      {
 			      for ( i = RETRO_DEVICE_ID_JOYPAD_B; i <= RETRO_DEVICE_ID_JOYPAD_R; i++)
 			      {
-				      bool pressed = input_cb(port, RETRO_DEVICE_JOYPAD_MULTITAP, j, i);
-				      uint16_t button_press = snes_lut[i];
+					bool pressed;
+					if (Settings.CurrentROMisMultitapCompatible==TRUE)
+						pressed = input_cb(port+j, RETRO_DEVICE_JOYPAD, 0, i);
+					else
+						pressed = input_cb(port, RETRO_DEVICE_JOYPAD, 0, i);
+						
+				      	uint16_t button_press = snes_lut[i];
 
-				      if (pressed)
-					      joypad[j*2+port] |= button_press;
-				      else
-					      joypad[j*2+port] &= ~button_press;
+				      	if (pressed)
+						joypad[j*2+port] |= button_press;
+				      	else
+						joypad[j*2+port] &= ~button_press;
 			      }
 		      }
 		      break;


### PR DESCRIPTION
If you set second RA-controller to a multitap device the second RA-controller will control SNES-controllers from 2 to 5, while input of RA-controller 3 to 5 is being ignored (e.g. in Bomberman).
This problem is fixed here. Sending pressed buttons of second RA-controller to all SNES-controllers except first seems to be needed for games which doesn't support multitap but have a two player mode being used with a connected multitap, so these cases are distinguished in the fix.
