### PR TITLE
Snapshot ICPU status registers

### DIFF
--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -181,7 +181,8 @@
 #define _SNAPSHOT_H_
 
 #define SNAPSHOT_MAGIC		"#!s9xsnp"
-#define SNAPSHOT_VERSION	6
+#define SNAPSHOT_VERSION_ICPU	7
+#define SNAPSHOT_VERSION	7
 
 #define SUCCESS			1
 #define WRONG_FORMAT		(-1)


### PR DESCRIPTION
This is a backport of [libretro/snes9x PR 26](https://github.com/libretro/snes9x/pull/26). Fixes snapshotting of status registers.