### PR TITLE
Pack status registers before snapshotting so they're not lost

### DIFF
--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -1259,6 +1259,8 @@ void S9xFreezeToStream (STREAM stream)
 	char	buffer[1024];
 	static uint8	soundsnapshot[SPC_SAVE_STATE_BLOCK_SIZE];
 
+        S9xPackStatus();
+
 	sprintf(buffer, "%s:%04d\n", SNAPSHOT_MAGIC, SNAPSHOT_VERSION);
 	WRITE_STREAM(buffer, strlen(buffer), stream);
 


### PR DESCRIPTION
Because of how LAGFIX works, status registers didn't always make it to the save state. This could easily be seen by simply serializing then unserializing every frame, which crashed a lot of games. This fixes that.