### PR TITLE
Flush audio buffer at end of retro_run, and bypass the resampler.

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -873,6 +873,10 @@ void retro_run (void)
    poll_cb();
    report_buttons();
    S9xMainLoop();
+   
+   //Force emptying the audio buffer at the end of the frame
+   S9xAudioCallback();
+
 }
 
 size_t retro_serialize_size (void)


### PR DESCRIPTION
Flushing the audio buffer and bypassing the resampler will ensure clean audio when loading state.