### PR TITLE
Flush audio buffer at the end of retro_run, and bypass resampler

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -873,6 +873,10 @@ void retro_run (void)
    poll_cb();
    report_buttons();
    S9xMainLoop();
+   
+   //Force emptying the audio buffer at the end of the frame
+   S9xAudioCallback();
+
 }
 
 size_t retro_serialize_size (void)

--- a/src/apu.c
+++ b/src/apu.c
@@ -3153,18 +3153,13 @@ static void resampler_read(short *data, int num_samples)
 	if (r_step == 65536)
 	{
 		//direct copy if we are not resampling
-		if (num_samples > rb_size)
-		{
-			num_samples = rb_size / sizeof(short);
-		}
-		
-		int bytesRemaining = rb_buffer_size - rb_start;
+		int bytesUntilBufferEnd = rb_buffer_size - rb_start;
 		while (num_samples > 0)
 		{
 			int bytesToConsume = num_samples * sizeof(short);
-			if (bytesToConsume >= bytesRemaining)
+			if (bytesToConsume >= bytesUntilBufferEnd)
 			{
-				bytesToConsume = bytesRemaining;
+				bytesToConsume = bytesUntilBufferEnd;
 			}
 			if (rb_start >= rb_buffer_size)
 			{


### PR DESCRIPTION
Second try, had a bug on the first submission.

This will force the sound buffer to be flushed at the end of retro_run, which makes rapidly saving and loading state have clean audio.

The resampler is also bypassed to avoid having samples linger on in there (may also improve performance).