### PR TITLE
Support discarding video frames

### DIFF
--- a/libretro/libretro-common/include/libretro.h
+++ b/libretro/libretro-common/include/libretro.h
@@ -967,6 +967,8 @@ enum retro_mod
                                             * core supports VFS before it starts handing out paths.
                                             * It is recomended to do so in retro_set_environment */
 
+#define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+
 /* Opaque file handle
  * Introduced in VFS API v1 */
 struct retro_vfs_file_handle;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -869,7 +869,16 @@ void retro_run (void)
    bool updated = false;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
    check_variables();
-   
+
+   int result = -1;
+   bool okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
+   if (!okay) result |= 3;
+   bool audioEnabled = 0 != (result & 2);
+   bool videoEnabled = 0 != (result & 1);
+
+   IPPU.RenderThisFrame = videoEnabled;
+   S9xSetSoundMute(!audioEnabled);
+
    poll_cb();
    report_buttons();
    S9xMainLoop();

--- a/src/controls.c
+++ b/src/controls.c
@@ -1460,7 +1460,8 @@ void S9xControlEOF (void)
          case MOUSE1:
             c = &mouse[i - MOUSE0].crosshair;
             if(Settings.Crosshair)
-               S9xDrawCrosshair(S9xGetCrosshair(c->img), c->fg, c->bg, mouse[i - MOUSE0].cur_x, mouse[i - MOUSE0].cur_y);
+               if (IPPU.RenderThisFrame)
+                  S9xDrawCrosshair(S9xGetCrosshair(c->img), c->fg, c->bg, mouse[i - MOUSE0].cur_x, mouse[i - MOUSE0].cur_y);
             break;
 
          case SUPERSCOPE:
@@ -1471,7 +1472,8 @@ void S9xControlEOF (void)
 
                c = &superscope.crosshair;
                if(Settings.Crosshair)
-                  S9xDrawCrosshair(S9xGetCrosshair(c->img), c->fg, c->bg, superscope.x, superscope.y);
+                  if (IPPU.RenderThisFrame)
+                     S9xDrawCrosshair(S9xGetCrosshair(c->img), c->fg, c->bg, superscope.x, superscope.y);
             }
 
             break;
@@ -1481,7 +1483,8 @@ void S9xControlEOF (void)
             {
                c = &justifier.crosshair[1];
                if(Settings.Crosshair)
-                  S9xDrawCrosshair(S9xGetCrosshair(c->img), c->fg, c->bg, justifier.x[1], justifier.y[1]);
+                  if (IPPU.RenderThisFrame)
+                     S9xDrawCrosshair(S9xGetCrosshair(c->img), c->fg, c->bg, justifier.x[1], justifier.y[1]);
             }
 
             i = (justifier.buttons & JUSTIFIER_SELECT) ?  1 : 0;
@@ -1500,7 +1503,8 @@ do_justifier:
                {
                   c = &justifier.crosshair[0];
                   if(Settings.Crosshair)
-                     S9xDrawCrosshair(S9xGetCrosshair(c->img), c->fg, c->bg, justifier.x[0], justifier.y[0]);
+                     if (IPPU.RenderThisFrame)
+                        S9xDrawCrosshair(S9xGetCrosshair(c->img), c->fg, c->bg, justifier.x[0], justifier.y[0]);
                }
             }
 

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -354,7 +354,7 @@ static int objsize_array[8][4] = {
 	{16,	32,	32,	32}, /*7*/
 };
 
-static void SetupOBJ (void)
+void SetupOBJ (void)
 {
 	int	Height, Y_two, SmallWidth, SmallHeight, LargeWidth, LargeHeight, inc, startline;
 	uint8	S, Y_one, line;
@@ -4065,7 +4065,10 @@ static void S9xDoDMA (void)
 		/* Prepare for accessing $2118-2119 */
 		if (d->BAddress == 0x18 || d->BAddress == 0x19)
 		{
-			FLUSH_REDRAW();
+			if (IPPU.RenderThisFrame)
+			{
+				FLUSH_REDRAW();
+			}
 		}
 
 		inc = d->AAddressFixed ? 0 : (!d->AAddressDecrement ? 1 : -1);
@@ -5353,6 +5356,7 @@ void S9xSoftResetPPU (void)
 		IPPU.ScreenColors[c] = c;
 	IPPU.RenderedScreenWidth = SNES_WIDTH;
 	IPPU.RenderedScreenHeight = SNES_HEIGHT;
+	IPPU.RenderThisFrame = TRUE;
 
 	S9xFixColourBrightness();
 

--- a/src/ppu.h
+++ b/src/ppu.h
@@ -299,6 +299,7 @@ struct InternalPPU
 	uint16	ScreenColors[256];
 	int	RenderedScreenWidth;
 	int	RenderedScreenHeight;
+	bool8 RenderThisFrame;
 };
 
 struct SOBJ

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -1870,6 +1870,7 @@ int S9xUnfreezeFromStream (STREAM stream)
 		CPU.HDMARanInDMA = 0;
 
 		S9xFixColourBrightness();
+		IPPU.RenderThisFrame = TRUE;
 		IPPU.OBJChanged = TRUE;
 
 		hdma_byte = Memory.FillRAM[0x420c];

--- a/src/snes9x.h
+++ b/src/snes9x.h
@@ -374,6 +374,7 @@ struct SSettings
 
 	uint32	SoundPlaybackRate;
 	uint32	SoundInputRate;
+	bool8	Mute;
 
 	bool8	Multi;
 	char	CartAName[PATH_MAX + 1];


### PR DESCRIPTION
This changeset adds these features:
- Support for checking if Audio and Video are enabled (which was just merged into RetroArch main)
- The IPPU.RenderThisFrame feature was backported from Snes9x main.
- Support for muting audio (currently just omits the copies to the buffers, as in Snes9x main)
