### PR TITLE
Add Fast Savestates and Hard Audio Disable

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -877,13 +877,21 @@ void retro_run (void)
       check_variables();
 
    okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
-   if (!okay)
-      result |= 3;
-   audioEnabled = (result & 2) != 0;
-   videoEnabled = (result & 1) != 0;
-
-   IPPU.RenderThisFrame = videoEnabled;
-   S9xSetSoundMute(!audioEnabled);
+   if (okay)
+   {
+      bool audioEnabled = 0 != (result & 2);
+      bool videoEnabled = 0 != (result & 1);
+	  bool hardDisableAudio = 0 != (result & 8);
+	  IPPU.RenderThisFrame = videoEnabled;
+	  S9xSetSoundMute(!audioEnabled || hardDisableAudio);
+	  Settings.HardDisableAudio = hardDisableAudio;
+   }
+   else
+   {
+      IPPU.RenderThisFrame = true;
+      S9xSetSoundMute(false);
+	  Settings.HardDisableAudio = false;
+   }
 
    poll_cb();
    report_buttons();
@@ -906,6 +914,13 @@ size_t retro_serialize_size (void)
 
 bool retro_serialize(void *data, size_t size)
 {
+   int result = -1;
+   bool okay = false;
+   okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
+   if (okay)
+   {
+      Settings.FastSavestates = 0 != (result & 4);
+   }
    memstream_set_buffer((uint8_t*)data, size);
    if (S9xFreezeGame("") == FALSE)
       return FALSE;
@@ -915,6 +930,13 @@ bool retro_serialize(void *data, size_t size)
 
 bool retro_unserialize(const void * data, size_t size)
 {
+   int result = -1;
+   bool okay = false;
+   okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
+   if (okay)
+   {
+      Settings.FastSavestates = 0 != (result & 4);
+   }
    memstream_set_buffer((uint8_t*)data, size);
    if (S9xUnfreezeGame("") == FALSE)
       return FALSE;

--- a/src/apu.c
+++ b/src/apu.c
@@ -857,8 +857,11 @@ V(V9_V6_V3,2) -> V(V9,2) V(V6,3) V(V3,4) */
 static void dsp_run( int clocks_remain )
 {
    dsp_voice_t *v0, *v1, *v2;
-	int phase = dsp_m.phase;
-	dsp_m.phase = (phase + clocks_remain) & 31;
+   int phase;
+   if (Settings.HardDisableAudio)
+      return;
+   phase = dsp_m.phase;
+   dsp_m.phase = (phase + clocks_remain) & 31;
 
    for (; clocks_remain > 0;)
    {

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -5197,6 +5197,21 @@ void S9xResetPPU (void)
 	PPU.M7byte = 0;
 }
 
+void S9xResetPPUFast (void)
+{
+	PPU.RecomputeClipWindows = TRUE;
+	IPPU.OBJChanged = TRUE;
+	IPPU.DirectColourMapsNeedRebuild = TRUE;
+	IPPU.RenderThisFrame = TRUE;
+	memset(IPPU.TileCached[TILE_2BIT], 0, MAX_2BIT_TILES);
+	memset(IPPU.TileCached[TILE_4BIT], 0, MAX_4BIT_TILES);
+	memset(IPPU.TileCached[TILE_8BIT], 0, MAX_8BIT_TILES);
+	memset(IPPU.TileCached[TILE_2BIT_EVEN], 0, MAX_2BIT_TILES);
+	memset(IPPU.TileCached[TILE_2BIT_ODD], 0,  MAX_2BIT_TILES);
+	memset(IPPU.TileCached[TILE_4BIT_EVEN], 0, MAX_4BIT_TILES);
+	memset(IPPU.TileCached[TILE_4BIT_ODD], 0,  MAX_4BIT_TILES);
+}
+
 void S9xSoftResetPPU (void)
 {
 	int c;

--- a/src/ppu.h
+++ b/src/ppu.h
@@ -438,6 +438,7 @@ extern struct SPPU		PPU;
 extern struct InternalPPU	IPPU;
 
 void S9xResetPPU (void);
+void S9xResetPPUFast (void);
 void S9xSoftResetPPU (void);
 void S9xSetPPU (uint8 Byte, uint16 Address);
 uint8 S9xGetPPU (uint16 Address);

--- a/src/snes9x.h
+++ b/src/snes9x.h
@@ -398,6 +398,8 @@ struct SSettings
 	bool8		SupportHiRes;
 	bool8		Transparency;
    float    SuperFXSpeedPerLine;
+   bool8	FastSavestates;
+   bool8	HardDisableAudio;
 };
 
 struct SSNESGameFixes


### PR DESCRIPTION
I've added Fast Savestates and Hard Audio Disable support to the emulator.

Fast savestates do this:
* Update the VRAM, RAM, SRAM, Fill Ram buffers in place without using an allocation and copy, and a couple other bufffers too
* Remove memory clear of loaded blocks
* Replace a full reset with just PPU tile cache invalidation, it was the only thing I found in my brief testing that actually needed initialization to fix issues.

And Hard Audio Disable stops emulating the Audio DSP and keeps the SPC700 CPU running.