### PR TITLE
[3DS] Fix crashes when loading savestates

### DIFF
--- a/src/blargg_endian.h
+++ b/src/blargg_endian.h
@@ -5,7 +5,7 @@
 #define BLARGG_ENDIAN
 
 /* Uncomment to enable platform-specific (and possibly non-portable) optimizations */
-#ifndef EMSCRIPTEN
+#if !defined(EMSCRIPTEN) && !defined(_3DS)
 #define BLARGG_NONPORTABLE 1
 #endif
 


### PR DESCRIPTION
The nonportable LE macros in Blargg SPU can allow unaligned loads, which cause ARM exceptions on 3DS.

The portable code avoids these problems, and generates good enough assembly, so it should be used instead.