### PR TITLE
Increase SRAM size

### DIFF
--- a/src/memmap.c
+++ b/src/memmap.c
@@ -367,7 +367,7 @@ static void S9xDeinterleaveGD24 (int size, uint8 *base)
 bool8 Init (void)
 {
 	Memory.RAM	 = (uint8 *) malloc(0x20000);
-	Memory.SRAM = (uint8 *) malloc(0x20000);
+	Memory.SRAM = (uint8 *) malloc(0x80000);
 	Memory.VRAM = (uint8 *) malloc(0x10000);
 	Memory.ROM  = (uint8 *) malloc(MAX_ROM_SIZE + 0x200 + 0x8000);
 
@@ -416,7 +416,7 @@ bool8 Init (void)
 	}
 
 	memset(Memory.RAM, 0,  0x20000);
-	memset(Memory.SRAM, 0, 0x20000);
+	memset(Memory.SRAM, 0, 0x80000);
 	memset(Memory.VRAM, 0, 0x10000);
 	memset(Memory.ROM, 0,  MAX_ROM_SIZE + 0x200 + 0x8000);
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -1285,7 +1285,7 @@ void S9xFreezeToStream (STREAM stream)
 
 	FreezeBlock (stream, "RAM", Memory.RAM, 0x20000);
 
-	FreezeBlock (stream, "SRA", Memory.SRAM, 0x20000);
+	FreezeBlock (stream, "SRA", Memory.SRAM, 0x80000);
 
 	FreezeBlock (stream, "FIL", Memory.FillRAM, 0x8000);
 
@@ -1752,9 +1752,9 @@ int S9xUnfreezeFromStream (STREAM stream)
 			break;
 
 		if (fast)
-			result = UnfreezeBlock(stream, "SRA", Memory.SRAM, 0x20000);
+			result = UnfreezeBlock(stream, "SRA", Memory.SRAM, 0x80000);
 		else
-		result = UnfreezeBlockCopy (stream, "SRA", &local_sram, 0x20000);
+		result = UnfreezeBlockCopy (stream, "SRA", &local_sram, 0x80000);
 		if (result != SUCCESS)
 			break;
 
@@ -1886,7 +1886,7 @@ int S9xUnfreezeFromStream (STREAM stream)
 			memcpy(Memory.RAM, local_ram, 0x20000);
 
 		if (local_sram)
-			memcpy(Memory.SRAM, local_sram, 0x20000);
+			memcpy(Memory.SRAM, local_sram, 0x80000);
 
 		if (local_fillram)
 			memcpy(Memory.FillRAM, local_fillram, 0x8000);


### PR DESCRIPTION
Increased SRAM size from 128KB to 512KB. This fixes a crash in the
Super Metroid Practice Hack when saving/loading state.

Fixes #147 