### PR TITLE
Assign map descriptors after ROM is loaded

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1420,9 +1420,6 @@ bool retro_load_game(const struct retro_game_info *game)
 	init_descriptors();
 	memorydesc_c = 0;
 
-	map.descriptors = memorydesc + MAX_MAPS - memorydesc_c;
-	map.num_descriptors = memorydesc_c;
-
 	/* Hack. S9x cannot do stuff from RAM. <_< */
 	memstream_set_buffer((uint8_t*)game->data, (uint64_t)game->size);
 
@@ -1444,6 +1441,10 @@ bool retro_load_game(const struct retro_game_info *game)
 
 	retro_set_audio_buff_status_cb();
 	set_system_specs();
+
+	map.descriptors = memorydesc + MAX_MAPS - memorydesc_c;
+	map.num_descriptors = memorydesc_c;
+
 	environ_cb(RETRO_ENVIRONMENT_SET_MEMORY_MAPS, &map);
 
 	return TRUE;


### PR DESCRIPTION
Moved the assignment of `map.descriptors` and `map.num_descriptors`
until after the ROM is loaded.  Since the descriptors are initialized as
part of loading the ROM, assigning these struct members prior to loading
the ROM meant that retroarch would never see any memory maps.  After
this change, I can see the maps in the retroarch log output, as
expected.

Fixes #150 