### PR TITLE
Fix the build with `armv` platform

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -596,7 +596,7 @@ $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
-	$(LD) $(LINKOUT)$@ $(SHARED) $(OBJECTS) $(LDFLAGS) $(LIBS)
+	$(LD) $(LINKOUT)$@ $(SHARED) $(OBJECTS) $(LDFLAGS) $(LIBS) $(LIBM)
 endif
 
 %.o: %.c


### PR DESCRIPTION
After 0fcbbdc2553d, building with `platform=armv` fails during linking with undefined references to functions from `libm`:
```
...
/usr/bin/ld: c4emu.c:(.text+0x1b64): undefined reference to `sqrt'
/usr/bin/ld: c4emu.c:(.text+0x1b74): undefined reference to `sqrt'
/usr/bin/ld: ./src/seta.o: in function `S9xSetST010':
seta.c:(.text+0x90c): undefined reference to `sqrt'
/usr/bin/ld: ./filter/snes_ntsc.o: in function `snes_ntsc_init':
snes_ntsc.c:(.text+0xa8): undefined reference to `pow'
/usr/bin/ld: snes_ntsc.c:(.text+0x108): undefined reference to `cos'
/usr/bin/ld: snes_ntsc.c:(.text+0x118): undefined reference to `cos'
/usr/bin/ld: snes_ntsc.c:(.text+0x134): undefined reference to `cos'
/usr/bin/ld: snes_ntsc.c:(.text+0x250): undefined reference to `cos'
/usr/bin/ld: snes_ntsc.c:(.text+0x260): undefined reference to `cos'
/usr/bin/ld: snes_ntsc.c:(.text+0x300): undefined reference to `exp'
/usr/bin/ld: snes_ntsc.c:(.text+0x430): undefined reference to `pow'
/usr/bin/ld: snes_ntsc.c:(.text+0x498): undefined reference to `sincos'
collect2: error: ld returned 1 exit status
```
so add back `$(LIBM)` for the final linking step. 