### PR TITLE
Improve save state efficiency + fix save state size

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1342,14 +1342,12 @@ void retro_run(void)
 
 size_t retro_serialize_size(void)
 {
-	/* FIXME: No fail check, magic large number, etc. */
-	uint8_t *tmpbuf = (uint8_t*)malloc(5000000);
-	memstream_set_buffer(tmpbuf, (uint64_t)5000000);
+	int32 size = SnapshotSize();
 
-	S9xFreezeGame();
-	free(tmpbuf);
+	if (size < 0)
+		return 0;
 
-	return memstream_get_last_size();
+	return (size_t)size;
 }
 
 bool retro_serialize(void *data, size_t size)

--- a/src/memmap.c
+++ b/src/memmap.c
@@ -764,7 +764,7 @@ static uint32 FileLoader (uint8 *buffer, int32 maxsize)
 
 	uint8	*ptr;
 	uint64_t	size      = 0;
-	STREAM fp          = OPEN_STREAM();
+	STREAM fp          = OPEN_STREAM(0);
 
 	Memory.HeaderCount = 0;
 	if (!fp)

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -194,4 +194,6 @@ bool8 S9xFreezeGame (void);
 bool8 S9xUnfreezeGame (void);
 int S9xUnfreezeFromStream (STREAM stream);
 
+int32 SnapshotSize(void);
+
 #endif

--- a/src/snes9x.h
+++ b/src/snes9x.h
@@ -220,7 +220,7 @@ extern "C" {
 #define WRITE_STREAM(p, l, s)    memstream_write(s, p, l)
 #define GETS_STREAM(p, l, s)     memstream_gets(s, p, l)
 #define GETC_STREAM(s)           memstream_getc(s)
-#define OPEN_STREAM()            memstream_open(0)
+#define OPEN_STREAM(w)           memstream_open(w)
 #define FIND_STREAM(f)           memstream_pos(f)
 #define REVERT_STREAM(f, o, s)   memstream_seek(f, o, s)
 #define CLOSE_STREAM(s)          memstream_close(s)


### PR DESCRIPTION
At present, every time that `retro_serialize_size()` is called (i.e whenever save states are used), the core determines the save state size by allocating a temporary 5 MB buffer and writing into this an actual save state. Moreover, it then fails to report the actual size correctly due to a bug in the memory stream wrapper code - which means save states are always 5 MB in size. This represents a terrible inefficiency.

With this PR, the save state size is now calculated independently of regular save state creation. No temporary buffer is required, and there is no need to actually write a save state to memory - and save states now have the correct size (~830 kb)
